### PR TITLE
avoid fs caches

### DIFF
--- a/lib/blog_snippets/articles/tuning_dd_block_size/dd_obs_test.sh
+++ b/lib/blog_snippets/articles/tuning_dd_block_size/dd_obs_test.sh
@@ -23,7 +23,7 @@ do
   fi
 
   # Create a test file with the specified block size
-  DD_RESULT=$(dd if=/dev/zero of=$TEST_FILE bs=$BLOCK_SIZE count=$COUNT 2>&1 1>/dev/null)
+  DD_RESULT=$(dd if=/dev/zero of=$TEST_FILE bs=$BLOCK_SIZE count=$COUNT conv=fsync 2>&1 1>/dev/null)
 
   # Extract the transfer rate from dd's STDERR output
   TRANSFER_RATE=$(echo $DD_RESULT | \grep --only-matching -E '[0-9.]+ ([MGk]?B|bytes)/s(ec)?')


### PR DESCRIPTION
conv=fsync makes dd avoid fs cache. Without it you get wrong measurements about actual disk speed.
